### PR TITLE
feat(renovate)!: move to Github-hosted preset

### DIFF
--- a/packages/renovate-config/README.md
+++ b/packages/renovate-config/README.md
@@ -1,13 +1,13 @@
-# renovate-config [![NPM version](https://img.shields.io/npm/v/@newhighsco/renovate-config.svg)](https://www.npmjs.com/package/@newhighsco/renovate-config)
+# renovate-config [![Github release](https://img.shields.io/github/package-json/v/newhighsco/config?filename=packages%2Frenovate-config%2Fpackage.json)](https://github.com/newhighsco/config/releases?q=renovate-config)
 
 New High Score [shareable config](https://docs.renovatebot.com/config-presets/) for [Renovate](http://renovatebot.com/)
 
 ## Usage
-New High Score Renovate rules come bundled in `@newhighsco/renovate-config`. To enable these rules, add a `renovate` property in your `package.json`. See the [Renovate configuration docs](https://docs.renovatebot.com/configuration-options/) for more details.
+New High Score Renovate rules are configured in [`default.json`](default.json). To enable these rules, add a `renovate` property in your `package.json`. See the [Renovate configuration docs](https://docs.renovatebot.com/configuration-options/) for more details.
 
 ```json
 "renovate": {
-  "extends": ["@newhighsco"]
+  "extends": ["github>newhighsco/config//packages/renovate-config/default"]
 }
 ```
 

--- a/packages/renovate-config/default.json
+++ b/packages/renovate-config/default.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "automerge": true,
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest",
+        "lockFileMaintenance",
+        "bump"
+      ]
+    },
+    {
+      "description": "Group New High Score packages together",
+      "groupName": "newhighsco packages",
+      "groupSlug": "newhighsco",
+      "matchPackagePatterns": ["^@newhighsco"]
+    },
+    {
+      "description": "Group Next.js packages and plugins together",
+      "extends": ["monorepo:nextjs"],
+      "groupName": "nextjs packages",
+      "groupSlug": "nextjs",
+      "matchPackagePatterns": ["^next"]
+    }
+  ],
+  "postUpdateOptions": ["yarnDedupeHighest"],
+  "prCreation": "not-pending",
+  "reviewers": ["team:reviewers"],
+  "stopUpdatingLabel": "blocked"
+}

--- a/packages/renovate-config/default.json
+++ b/packages/renovate-config/default.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended"
+  ],
   "packageRules": [
     {
       "automerge": true,
@@ -17,18 +19,28 @@
       "description": "Group New High Score packages together",
       "groupName": "newhighsco packages",
       "groupSlug": "newhighsco",
-      "matchPackagePatterns": ["^@newhighsco"]
+      "matchPackagePatterns": [
+        "^@newhighsco"
+      ]
     },
     {
       "description": "Group Next.js packages and plugins together",
-      "extends": ["monorepo:nextjs"],
+      "extends": [
+        "monorepo:nextjs"
+      ],
       "groupName": "nextjs packages",
       "groupSlug": "nextjs",
-      "matchPackagePatterns": ["^next"]
+      "matchPackagePatterns": [
+        "^next"
+      ]
     }
   ],
-  "postUpdateOptions": ["yarnDedupeHighest"],
+  "postUpdateOptions": [
+    "yarnDedupeHighest"
+  ],
   "prCreation": "not-pending",
-  "reviewers": ["team:reviewers"],
+  "reviewers": [
+    "team:reviewers"
+  ],
   "stopUpdatingLabel": "blocked"
 }

--- a/packages/renovate-config/package.json
+++ b/packages/renovate-config/package.json
@@ -4,7 +4,7 @@
   "version": "1.9.0",
   "author": "New High Score <hello@newhighsco.re>",
   "license": "ISC",
-  "private": false,
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/newhighsco/config.git",
@@ -16,56 +16,14 @@
   },
   "files": [],
   "scripts": {
-    "test": "renovate-config-validator"
+    "test": "RENOVATE_CONFIG_FILE=default.json renovate-config-validator"
   },
   "devDependencies": {
     "renovate": "36.3.0"
   },
-  "renovate-config": {
-    "default": {
-      "extends": [
-        "config:base"
-      ],
-      "packageRules": [
-        {
-          "automerge": true,
-          "matchUpdateTypes": [
-            "minor",
-            "patch",
-            "pin",
-            "digest",
-            "lockFileMaintenance",
-            "bump"
-          ]
-        },
-        {
-          "description": "Group New High Score packages together",
-          "groupName": "newhighsco packages",
-          "groupSlug": "newhighsco",
-          "matchPackagePatterns": [
-            "^@newhighsco"
-          ]
-        },
-        {
-          "description": "Group Next.js packages and plugins together",
-          "extends": [
-            "monorepo:nextjs"
-          ],
-          "groupName": "nextjs packages",
-          "groupSlug": "nextjs",
-          "matchPackagePatterns": [
-            "^next"
-          ]
-        }
-      ],
-      "postUpdateOptions": [
-        "yarnDedupeHighest"
-      ],
-      "prCreation": "not-pending",
-      "reviewers": [
-        "team:reviewers"
-      ],
-      "stopUpdatingLabel": "blocked"
-    }
+  "renovate": {
+    "extends": [
+      "github>newhighsco/config//packages/renovate-config/default"
+    ]
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: `@newhighsco/renovate-config` will no longer be published