### PR TITLE
feat(stylelint-config)!: add `stylelint-order` plugin

### DIFF
--- a/packages/stylelint-config/__tests__/test.scss
+++ b/packages/stylelint-config/__tests__/test.scss
@@ -5,8 +5,22 @@
 
 $avatar-width-small: functions.rem(48);
 
+@mixin clearfix {
+  &::before,
+  &::after {
+    content: '';
+    display: table;
+  }
+
+  &::after {
+    clear: both;
+  }
+}
+
 .test {
   content: 'test';
+
+  @include clearfix;
 }
 
 /**

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -23,6 +23,7 @@
     "stylelint-config-css-modules": "4.4.0",
     "stylelint-config-prettier": "9.0.5",
     "stylelint-config-standard-scss": "14.0.0",
+    "stylelint-order": "6.0.4",
     "stylelint-prettier": "5.0.2"
   },
   "devDependencies": {

--- a/packages/stylelint-config/stylelint.config.js
+++ b/packages/stylelint-config/stylelint.config.js
@@ -4,6 +4,7 @@ module.exports = {
     'stylelint-prettier/recommended',
     'stylelint-config-css-modules'
   ],
+  plugins: ['stylelint-order'],
   rules: {
     // Handle collision between SCSS and CSS Modules rules
     // See: https://github.com/pascalduez/stylelint-config-css-modules/issues/6#issuecomment-640194712
@@ -27,6 +28,7 @@ module.exports = {
           'composes'
         ]
       }
-    ]
+    ],
+    'order/order': ['custom-properties', 'declarations', 'at-rules', 'rules']
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9060,12 +9060,17 @@ postcss-selector-parser@^7.0.0:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
+postcss-sorting@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-sorting/-/postcss-sorting-8.0.2.tgz#6393385ece272baf74bee9820fb1b58098e4eeca"
+  integrity sha512-M9dkSrmU00t/jK7rF6BZSZauA5MAaBW4i5EnJXspMwt4iqTh/L9j6fgMnbElEOfyRyfLfVbIHj/R52zHzAPe1Q==
+
 postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.4, postcss@^8.4.49:
+postcss@^8.4.32, postcss@^8.4.4, postcss@^8.4.49:
   version "8.4.49"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.49.tgz#4ea479048ab059ab3ae61d082190fabfd994fe19"
   integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
@@ -10556,6 +10561,14 @@ stylelint-config-standard@^36.0.1:
   integrity sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==
   dependencies:
     stylelint-config-recommended "^14.0.1"
+
+stylelint-order@6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-6.0.4.tgz#3e80d876c61a98d2640de181433686f24284748b"
+  integrity sha512-0UuKo4+s1hgQ/uAxlYU4h0o0HS4NiQDud0NAUNI0aa8FJdmYHA5ZZTFHiV5FpmE3071e9pZx5j0QpVJW5zOCUA==
+  dependencies:
+    postcss "^8.4.32"
+    postcss-sorting "^8.0.2"
 
 stylelint-prettier@5.0.2:
   version "5.0.2"


### PR DESCRIPTION
BREAKING CHANGE: Enforces ordering of CSS/SCSS files