### PR TITLE
fix(release-config): prevent empty CHANGELOG

### DIFF
--- a/packages/release-config/package.json
+++ b/packages/release-config/package.json
@@ -27,7 +27,7 @@
     "@semantic-release/github": "12.0.9",
     "@semantic-release/npm": "13.1.5",
     "@semantic-release/release-notes-generator": "14.1.1",
-    "conventional-changelog-conventionalcommits": "10.2.1"
+    "conventional-changelog-conventionalcommits": "9.3.1"
   },
   "peerDependencies": {
     "semantic-release": "25.0.8",

--- a/packages/release-config/renovate-config.json
+++ b/packages/release-config/renovate-config.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
-    { "extends": ["monorepo:semantic-release"], "semanticCommitType": "fix" }
+    { "extends": ["monorepo:semantic-release"], "semanticCommitType": "fix" },
+    {
+      "description": "Pin `conventional-changelog-conventionalcommits` to v9 - https://github.com/semantic-release/commit-analyzer/issues/921",
+      "matchPackageNames": ["conventional-changelog-conventionalcommits"],
+      "allowedVersions": "<10"
+    }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,7 +1520,7 @@ __metadata:
     "@semantic-release/github": "npm:12.0.9"
     "@semantic-release/npm": "npm:13.1.5"
     "@semantic-release/release-notes-generator": "npm:14.1.1"
-    conventional-changelog-conventionalcommits: "npm:10.2.1"
+    conventional-changelog-conventionalcommits: "npm:9.3.1"
   peerDependencies:
     semantic-release: 25.0.8
     semantic-release-circleci-orb: 1.1.1
@@ -4455,7 +4455,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-conventionalcommits@npm:10.2.1, conventional-changelog-conventionalcommits@npm:^10.0.0":
+"conventional-changelog-conventionalcommits@npm:9.3.1":
+  version: 9.3.1
+  resolution: "conventional-changelog-conventionalcommits@npm:9.3.1"
+  dependencies:
+    compare-func: "npm:^2.0.0"
+  checksum: 10c0/e3d0dfe5680899da3660a7fbc859de1a92dd9358dc497624c3582596173713a80dcc8236d844116a3ba8403350e244c007c0c7fa5796631aea19e464cc6c2f44
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-conventionalcommits@npm:^10.0.0":
   version: 10.2.1
   resolution: "conventional-changelog-conventionalcommits@npm:10.2.1"
   dependencies:


### PR DESCRIPTION
Pinned `conventional-changelog-conventionalcommits` to v9 as updated to v10 is currently blocked:
- https://github.com/semantic-release/commit-analyzer/issues/921